### PR TITLE
Return valid null values in the masked object

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -40,7 +40,7 @@ function _properties(obj, mask) {
     } else if ('array' === value.type) {
       ret = _array(obj, key, value.properties)
     }
-    if ((null !== ret) && ('undefined' !== typeof ret)) {
+    if ('undefined' !== typeof ret) {
       maskedObj[key] = ret
     }
   }


### PR DESCRIPTION
null is a valid value in JSON and should therefore be returned in a masked object when correctly matched by a pattern
