### PR TITLE
Don't filter falsey values out of plain arrays.

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -64,7 +64,7 @@ function _array(object, key, mask) {
   for (i = 0, l = arr.length; i < l; i++) {
     obj = arr[i]
     maskedObj = _properties(obj, mask)
-    if (maskedObj) ret.push(maskedObj)
+    if ('undefined' !== typeof maskedObj) ret.push(maskedObj)
   }
   return ret.length ? ret : undefined
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -114,6 +114,14 @@ tests = [{
     m: 'foo(bar)'
   , o: { foo: 1234 }
   , e: null
+}, {
+    m: 'a'
+  , o: { a: [0, 0] }
+  , e: { a: [0, 0] }
+}, {
+    m: 'a'
+  , o: { a: [1, 0, 1] }
+  , e: { a: [1, 0, 1] }
 }]
 
 describe('json-mask', function () {


### PR DESCRIPTION
As it is in 0.3.4, applying the mask `a` to `{a: [1, 0, 1]}` will return `{a: [1, 1]}`. That's definitely not what I would expect. Furthermore, if the array has only falsey values - `{a: [0, 0]}`, for instance - the result is `null` - there's special-case handling to return the array itself if it is empty, but here the array isn't actually empty.

As far as I can tell, in line 66 of `lib/filter.js`, the if statement should be checking explicitly against undefined, as _properties and _forAll are already doing, and with that change, falsey values in arrays are handled correctly.