### PR TITLE
add failing test case

### DIFF
--- a/test/compiler-test.js
+++ b/test/compiler-test.js
@@ -30,6 +30,15 @@ tests = {
       b: {type: 'object'}
     }},
     c: {type: 'object'}
+  },
+  'a,b(c/d),e': {
+    a: {type: 'object'},
+    b: {type: 'array', properties: {
+      c: {type: 'object', properties: {
+        d: {type: 'object'}
+      }}
+    }},
+    e: {type: 'object'}
   }
 }
 


### PR DESCRIPTION
If I've understood the returned ast from `jsonMask.compile()` correctly, then `a,b(c/d),e` is parsed incorrectly. I've attached a failing test case.

I'm walking the result from the compile function manually since I'm doing the filtering on the db level.