### PR TITLE
Fix compiler stack bug

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -54,10 +54,10 @@ function scan (text) {
 }
 
 function parse (tokens) {
-  return _buildTree(tokens, {}, [])
+  return _buildTree(tokens, {}, [], [])
 }
 
-function _buildTree (tokens, parent, stack) {
+function _buildTree (tokens, parent, arrayStack, objectStack) {
   var props = {}
   var token
   var peek
@@ -65,25 +65,25 @@ function _buildTree (tokens, parent, stack) {
   while ((token = tokens.shift())) {
     if (token.tag === '_n') {
       token.type = 'object'
-      token.properties = _buildTree(tokens, token, stack)
+      token.properties = _buildTree(tokens, token, arrayStack, objectStack)
       // exit if in object stack
-      peek = stack[stack.length - 1]
+      peek = objectStack[objectStack.length - 1]
       if (peek && (peek.tag === '/')) {
-        stack.pop()
+        objectStack.pop()
         _addToken(token, props)
         return props
       }
     } else if (token.tag === ',') {
       return props
     } else if (token.tag === '(') {
-      stack.push(token)
+      arrayStack.push(token)
       parent.type = 'array'
       continue
     } else if (token.tag === ')') {
-      stack.pop(token)
+      arrayStack.pop(token)
       return props
     } else if (token.tag === '/') {
-      stack.push(token)
+      objectStack.push(token)
       continue
     }
     _addToken(token, props)

--- a/test/compiler-test.js
+++ b/test/compiler-test.js
@@ -30,6 +30,14 @@ tests = {
       b: {type: 'object'}
     }},
     c: {type: 'object'}
+  },
+  'a(b/c),d': {
+    a: {type: 'array', properties: {
+      b: {type: 'object', properties: {
+        c: {type: 'object'}
+      }}
+    }},
+    d: {type: 'object'}
   }
 }
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -95,6 +95,10 @@ tests = [{
   o: {p1: {a: 1, b: 1, c: 1}, p2: {a: 2, b: 2, c: 2}},
   e: {p1: {a: 1, b: 1}, p2: {a: 2, b: 2}}
 }, {
+  m: 'a(b/c),e',
+  o: {a: [{b: {c: 1}}, {d: 2}], e: 3, f: 4, g: 5},
+  e: {a: [{b: {c: 1}}, {}], e: 3}
+}, {
   m: 'kind',
   o: fixture,
   e: {kind: 'plus#activity'}


### PR DESCRIPTION
When a mask has an object inside of an array, e.g., `a(b/c),d` and the closing of the array is immediately follows the ending of the nested object, the `(` token is not properly popped off the stack array. 
In this example when you get to the `)` token, the stack is `['(', '/']` and `)` pops off the `/`. This leaves the `(` perpetually in the stack, and the `d` object to be placed in `a` array. 

I have changed the behavior of the compiler to now have 2 stacks. One for arrays and one for objects. This allows them to keep track of their own state.
