### PR TITLE
feat: add escape sequence for terminal characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Take a look at `test/index-test.js` for examples of all of these and more.
       Prop ::= Object | Array
     Object ::= NAME | NAME "/" Prop
      Array ::= NAME "(" Props ")"
-      NAME ::= ? all visible characters ? | EscapeSeq | Wildcard
+      NAME ::= ? all visible characters except "\" ? | EscapeSeq | Wildcard
   Wildcard ::= "*"
- EscapeSeq ::= "\" ("," | "*" | "/" | "(" | ")")
+ EscapeSeq ::= "\" ? all visible characters ?
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Take a look at `test/index-test.js` for examples of all of these and more.
 ## Grammar
 
 ```
-  Props ::= Prop | Prop "," Props
-   Prop ::= Object | Array
- Object ::= NAME | NAME "/" Prop
-  Array ::= NAME "(" Props ")"
-   NAME ::= ? all visible characters ?
+     Props ::= Prop | Prop "," Props
+      Prop ::= Object | Array
+    Object ::= NAME | NAME "/" Prop
+     Array ::= NAME "(" Props ")"
+      NAME ::= ? all visible characters ? | EscapeSeq | Wildcard
+  Wildcard ::= "*"
+ EscapeSeq ::= "\" ("," | "*" | "/" | "(" | ")")
 ```
 
 ## Examples
@@ -110,6 +112,28 @@ var assert = require('assert');
 
 var maskedObj = mask(originalObj, fields);
 assert.deepEqual(maskedObj, expectObj);
+```
+
+### Escaping
+
+It is also possible to get keys that contain `,*()/` using `\` (backslash) as escape character.
+
+```json
+{
+  "metadata": {
+    "labels": {
+      "app.kubernetes.io/name": "mysql",
+      "location": "WH1"
+    }
+  }
+}
+```
+
+You can filter out the location property by `metadata(labels(app.kubernetes.io\/name))` mask.
+
+NOTE: In [JavaScript String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#escape_sequences) you must escape backslash with another backslash:
+```js
+var fields = 'metadata(labels(app.kubernetes.io\\/name))'
 ```
 
 ### Partial Responses Server Example

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -13,9 +13,9 @@ module.exports = compile
  *      Prop ::= Object | Array
  *    Object ::= NAME | NAME "/" Prop
  *     Array ::= NAME "(" Props ")"
- *      NAME ::= ? all visible characters ? | EscapeSeq | Wildcard
+ *      NAME ::= ? all visible characters except "\" ? | EscapeSeq | Wildcard
  *  Wildcard ::= "*"
- * EscapeSeq ::= "\" ("," | "*" | "/" | "(" | ")")
+ * EscapeSeq ::= "\" ? all visible characters ?
  *
  *  Examples:
  *    a

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,5 +1,6 @@
 var util = require('./util')
-var TERMINALS = { ',': 1, '/': 2, '(': 3, ')': 4 }
+var TERMINALS = { ',': 1, '/': 2, '(': 3, ')': 4, '*': 5 }
+var ESCAPE_CHAR = '\\'
 
 module.exports = compile
 
@@ -11,7 +12,9 @@ module.exports = compile
  *      Prop ::= Object | Array
  *    Object ::= NAME | NAME "/" Prop
  *     Array ::= NAME "(" Props ")"
- *      NAME ::= ? all visible characters ?
+ *      NAME ::= ? all visible characters ? | EscapeSeq | Wildcard
+ *  Wildcard ::= "*"
+ * EscapeSeq ::= "\" ("," | "*" | "/" | "(" | ")")
  *
  *  Examples:
  *    a
@@ -19,6 +22,7 @@ module.exports = compile
  *    a/b/c
  *    a(b)
  *    ob,a(k,z(f,g/d)),d
+ *    a\/b/c
  */
 
 function compile (text) {
@@ -31,6 +35,7 @@ function scan (text) {
   var len = text.length
   var tokens = []
   var name = ''
+  var escape = false
   var ch
 
   function maybePushName () {
@@ -41,12 +46,17 @@ function scan (text) {
 
   for (; i < len; i++) {
     ch = text.charAt(i)
-    if (TERMINALS[ch]) {
+    if (ch === ESCAPE_CHAR) {
+      escape = true
+      continue
+    }
+    if (TERMINALS[ch] && escape !== true) {
       maybePushName()
       tokens.push({ tag: ch })
     } else {
       name += ch
     }
+    escape = false
   }
   maybePushName()
 
@@ -62,7 +72,7 @@ function _buildTree (tokens, parent) {
   var token
 
   while ((token = tokens.shift())) {
-    if (token.tag === '_n') {
+    if (token.tag === '_n' || token.tag === '*') {
       token.type = 'object'
       token.properties = _buildTree(tokens, token)
       if (parent.hasChild) {
@@ -87,8 +97,10 @@ function _buildTree (tokens, parent) {
 }
 
 function _addToken (token, props) {
-  props[token.value] = { type: token.type }
+  var prop = { type: token.type }
+  if (token.tag === '*') prop.filter = true
   if (!util.isEmpty(token.properties)) {
-    props[token.value].properties = token.properties
+    prop.properties = token.properties
   }
+  props[token.value || token.tag] = prop
 }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,6 +1,7 @@
 var util = require('./util')
-var TERMINALS = { ',': 1, '/': 2, '(': 3, ')': 4, '*': 5 }
+var TERMINALS = { ',': 1, '/': 2, '(': 3, ')': 4 }
 var ESCAPE_CHAR = '\\'
+var WILDCARD_CHAR = '*'
 
 module.exports = compile
 
@@ -46,13 +47,15 @@ function scan (text) {
 
   for (; i < len; i++) {
     ch = text.charAt(i)
-    if (ch === ESCAPE_CHAR) {
+    if (ch === ESCAPE_CHAR && !escape) {
       escape = true
       continue
     }
-    if (TERMINALS[ch] && escape !== true) {
+    if (TERMINALS[ch] && !escape) {
       maybePushName()
       tokens.push({ tag: ch })
+    } else if (ch === WILDCARD_CHAR && !name.length && !escape) {
+      tokens.push({ tag: ch, value: ch })
     } else {
       name += ch
     }
@@ -98,9 +101,11 @@ function _buildTree (tokens, parent) {
 
 function _addToken (token, props) {
   var prop = { type: token.type }
-  if (token.tag === '*') prop.filter = true
   if (!util.isEmpty(token.properties)) {
     prop.properties = token.properties
   }
-  props[token.value || token.tag] = prop
+  if (token.tag === WILDCARD_CHAR) {
+    prop.filter = true
+  }
+  props[token.value] = prop
 }

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -32,7 +32,7 @@ function _properties (obj, mask) {
     value = mask[key]
     ret = undefined
     typeFunc = (value.type === 'object') ? _object : _array
-    if (key === '*') {
+    if (value.filter) {
       ret = _forAll(obj, value.properties, typeFunc)
       for (retKey in ret) {
         if (!util.has(ret, retKey)) continue

--- a/test/compiler-test.js
+++ b/test/compiler-test.js
@@ -18,6 +18,7 @@ tests = {
       properties: {
         '*': {
           type: 'object',
+          filter: true,
           properties: {
             c: { type: 'object' }
           }
@@ -35,6 +36,7 @@ tests = {
           properties: {
             '*': {
               type: 'object',
+              filter: true,
               properties: {
                 g: { type: 'object' }
               }
@@ -113,6 +115,46 @@ tests = {
       }
     },
     e: { type: 'object' }
+  },
+  'a\\/b\\/c': {
+    'a/b/c': {
+      type: 'object'
+    }
+  },
+  'a\\(b\\)c': {
+    'a(b)c': {
+      type: 'object'
+    }
+  },
+  'a\\bc': {
+    abc: {
+      type: 'object'
+    }
+  },
+  '\\*': {
+    '*': {
+      type: 'object'
+    }
+  },
+  '*': {
+    '*': {
+      type: 'object',
+      filter: true
+    }
+  },
+  '*(a,b,\\*,\\(,\\),\\,)': {
+    '*': {
+      type: 'array',
+      filter: true,
+      properties: {
+        a: { type: 'object' },
+        b: { type: 'object' },
+        '*': { type: 'object' },
+        '(': { type: 'object' },
+        ')': { type: 'object' },
+        ',': { type: 'object' },
+      }
+    }
   }
 }
 

--- a/test/compiler-test.js
+++ b/test/compiler-test.js
@@ -173,6 +173,11 @@ tests = {
     n: {
       type: 'object'
     }
+  },
+  'multi\nline': {
+    'multi\nline': {
+      type: 'object'
+    }
   }
 }
 

--- a/test/compiler-test.js
+++ b/test/compiler-test.js
@@ -152,8 +152,18 @@ tests = {
         '*': { type: 'object' },
         '(': { type: 'object' },
         ')': { type: 'object' },
-        ',': { type: 'object' },
+        ',': { type: 'object' }
       }
+    }
+  },
+  '\\\\': {
+    '\\': {
+      type: 'object'
+    }
+  },
+  'foo*bar': {
+    'foo*bar': {
+      type: 'object'
     }
   }
 }

--- a/test/compiler-test.js
+++ b/test/compiler-test.js
@@ -126,6 +126,7 @@ tests = {
       type: 'object'
     }
   },
+  // escaped b (`\b`) in our language resolves to `b` character.
   'a\\bc': {
     abc: {
       type: 'object'
@@ -163,6 +164,13 @@ tests = {
   },
   'foo*bar': {
     'foo*bar': {
+      type: 'object'
+    }
+  },
+  // mask `\n`, should not resolve in a new line,
+  // because we simply escape "n" character which has no meaning in our language
+  '\\n': {
+    n: {
       type: 'object'
     }
   }

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -17,6 +17,7 @@ compiledMask = {
         properties: {
           '*': {
             type: 'object',
+            filter: true,
             properties: {
               z: { type: 'object' }
             }
@@ -31,7 +32,9 @@ compiledMask = {
       }
     }
   },
-  c: { type: 'object' }
+  c: { type: 'object' },
+  'd/e': { type: 'object' },
+  '*': { type: 'object' }
 }
 
 object = {
@@ -43,7 +46,9 @@ object = {
     k: 99
   }],
   c: 44,
-  g: 99
+  g: 99,
+  'd/e': 101,
+  '*': 110
 }
 
 expected = {
@@ -57,7 +62,9 @@ expected = {
     },
     b: [{}]
   }],
-  c: 44
+  c: 44,
+  'd/e': 101,
+  '*': 110
 }
 
 describe('filter', function () {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -167,6 +167,50 @@ tests = [{
     beta: { first: 'fv', second: { third: 'tv' } },
     cappa: { first: 'fv', second: { third: 'tv' } }
   }
+}, {
+  m: 'beta(first,second\\/third),cappa(first,second\\/third)',
+  o: {
+    alpha: 3,
+    beta: { first: 'fv', 'second/third': 'tv', third: { fourth: 'fv' } },
+    cappa: { first: 'fv', 'second/third': 'tv', third: { fourth: 'fv' } }
+  },
+  e: {
+    beta: { first: 'fv', 'second/third': 'tv' },
+    cappa: { first: 'fv', 'second/third': 'tv' }
+  }
+}, {
+  m: '\\*',
+  o: {
+    '*': 101,
+    beta: 'hidden'
+  },
+  e: {
+    '*': 101
+  }
+}, {
+  m: 'first(\\*)',
+  o: {
+    first: {
+      '*': 101,
+      beta: 'hidden'
+    }
+  },
+  e: {
+    first: {
+      '*': 101
+    }
+  }
+}, {
+  m: 'some,\\*',
+  o: {
+    '*': 101,
+    beta: 'hidden',
+    some: 'visible'
+  },
+  e: {
+    '*': 101,
+    some: 'visible'
+  }
 }]
 
 describe('json-mask', function () {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -211,6 +211,17 @@ tests = [{
     '*': 101,
     some: 'visible'
   }
+}, {
+  m: 'some,\\\\',
+  o: {
+    '\\': 120,
+    beta: 'hidden',
+    some: 'visible'
+  },
+  e: {
+    '\\': 120,
+    some: 'visible'
+  }
 }]
 
 describe('json-mask', function () {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -222,6 +222,21 @@ tests = [{
     '\\': 120,
     some: 'visible'
   }
+}, {
+  m: 'multi\nline(a)',
+  o: {
+    multi: 130,
+    line: 131,
+    'multi\nline': {
+      a: 135,
+      b: 134
+    }
+  },
+  e: {
+    'multi\nline': {
+      a: 135
+    }
+  }
 }]
 
 describe('json-mask', function () {


### PR DESCRIPTION
allows filtering properties that contains special characters `,*()/`

use `\` (backslash) for escaping such characters:
- `foo\/bar`, will filter JSON property that matches `foo/bar`

fixes #164