### PR TITLE
Fix trailing escape handling in compiler

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -48,6 +48,10 @@ function scan (text) {
     ch = text.charAt(i)
     if (ch === ESCAPE_CHAR) {
       i++
+      if (i >= len) {
+        name += ESCAPE_CHAR
+        break
+      }
       ch = text.charAt(i)
       name += ch === WILDCARD_CHAR ? ESCAPE_CHAR + WILDCARD_CHAR : ch
     } else if (TERMINALS[ch]) {

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -106,7 +106,7 @@ var tests = [
     },
     e (result) {
       assert.strictEqual(result.exitCode, 1, 'exit code must be 1')
-      assert.ok(/Unexpected/.test(result.stderr))
+      assert.ok(/Unexpected|Expected/.test(result.stderr))
       assert.ok(/usage:/i.test(result.stdout))
     }
   },
@@ -116,7 +116,7 @@ var tests = [
     mask: 's',
     e (result) {
       assert.strictEqual(result.exitCode, 1, 'exit code must be 1')
-      assert.ok(/Unexpected/.test(result.stderr))
+      assert.ok(/Unexpected|Expected/.test(result.stderr))
       assert.ok(/usage:/i.test(result.stdout))
     }
   },

--- a/test/compiler-test.js
+++ b/test/compiler-test.js
@@ -167,6 +167,11 @@ tests = {
       type: 'object'
     }
   },
+  'foo\\': {
+    'foo\\': {
+      type: 'object'
+    }
+  },
   // mask `\n`, should not resolve in a new line,
   // because we simply escape "n" character which has no meaning in our language
   '\\n': {


### PR DESCRIPTION
## Summary
- handle trailing escape in the scanner
- widen regex for CLI parse errors so Node 22 passes
- restore original package-lock.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840b03edab8832f8eaad2465a1dccc1