### PR TITLE
Fix spelling of server startup message

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -20,7 +20,7 @@ server = http.createServer(function (req, res) {
 
 server.listen(4000, function () {
   var prefix = 'curl \'http://localhost:4000%s?fields=%s\''
-  console.log('Server runnong on :4000, try the following:')
+  console.log('Server running on :4000, try the following:')
   console.log(prefix, '/', 'title')
   console.log(prefix, '/', 'kind,updated')
   console.log(prefix, '/', 'url,object(content,attachments/url)')


### PR DESCRIPTION
## Summary
- fix spelling in `example/server.js`

## Testing
- `npm test` *(fails: cli should error with invalid JSON file input)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb25977c832f8630dce206ab091a